### PR TITLE
Changes to add bfloat16 support for Random Fourier Features

### DIFF
--- a/keras/layers/kernelized.py
+++ b/keras/layers/kernelized.py
@@ -225,8 +225,9 @@ class RandomFourierFeatures(base_layer.Layer):
         super().build(input_shape)
 
     def call(self, inputs):
-        inputs = tf.convert_to_tensor(inputs, dtype=self.dtype)
-        inputs = tf.cast(inputs, tf.float32)
+        cdtype = self.compute_dtype if self.compute_dtype != self.dtype else self.dtype
+        inputs = tf.convert_to_tensor(inputs, dtype=cdtype)
+        inputs = tf.cast(inputs, cdtype) if inputs.dtype !=cdtype else inputs
         kernel = (1.0 / self.kernel_scale) * self.unscaled_kernel
         outputs = tf.matmul(a=inputs, b=kernel)
         outputs = tf.nn.bias_add(outputs, self.bias)


### PR DESCRIPTION
These changes add bfloat16 support for RandomFourierFeatures. When precision is set as mixed_bfloat16 for models it is optimal to have as many layers in bfloat16. We have models that show better performance with bfloat16 for RandomFourierFeatures